### PR TITLE
Upgrade Ruby to 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.1.2"
+ruby "2.3.1"
 
 gem "sinatra"
 gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     daemons (1.1.9)
-    eventmachine (1.0.3)
+    eventmachine (1.2.0.1)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -22,3 +22,9 @@ PLATFORMS
 DEPENDENCIES
   sinatra
   thin
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
This also adds the explicit version to `Gemfile.lock` to avoid issues like https://github.com/flynn/flynn/issues/3319.

/cc @lenn4rd